### PR TITLE
Use infs for default metrics values

### DIFF
--- a/bigearthnet/utils/callbacks.py
+++ b/bigearthnet/utils/callbacks.py
@@ -126,10 +126,10 @@ class MonitorHyperParameters(Callback):
     def init_hparams_metrics(self, trainer, pl_module):
         # Set up initial metrics associated to hparams before training
         init_metrics = {
-            "val_best_metrics/loss": float('inf'),
-            "val_best_metrics/precision": float('-inf'),
-            "val_best_metrics/recall": float('-inf'),
-            "val_best_metrics/f1_score": float('-inf'),
+            "val_best_metrics/loss": float("inf"),
+            "val_best_metrics/precision": float("-inf"),
+            "val_best_metrics/recall": float("-inf"),
+            "val_best_metrics/f1_score": float("-inf"),
         }
 
         # verify that the value we want to monitor is valid


### PR DESCRIPTION
Having e.g. macro-f1 default to 0 means that if the macro-f1 is 0 after epoch 0, and remains 0, the hyper parameters never get updated in tensorboard. This is fixed by putting default values to either +/- inf.