### PR TITLE
Update baseline to contain zero padding

### DIFF
--- a/bigearthnet/models/nets/baseline.py
+++ b/bigearthnet/models/nets/baseline.py
@@ -27,20 +27,20 @@ class Baseline(torch.nn.Module):  # pragma: no cover
         super(Baseline, self).__init__()
         self.model_name = model_name
         self.conv_layers = nn.Sequential(
-            nn.Conv2d(3, 32, 5),
+            nn.Conv2d(3, 32, 5, padding="same"),
             nn.ReLU(),
             nn.MaxPool2d(2),
-            nn.Conv2d(32, 32, 5),
+            nn.Conv2d(32, 32, 5, padding="same"),
             nn.ReLU(),
             nn.MaxPool2d(2),
-            nn.Conv2d(32, 64, 3),
+            nn.Conv2d(32, 64, 3, padding="same"),
             nn.ReLU(),
             nn.MaxPool2d(2),
         )
         self.flatten = nn.Flatten()
         self.mlp_layers = nn.Sequential(
             nn.Linear(
-                9216,
+                14400,
                 hidden_dim,
             ),  # The input size for the linear layer is determined by the previous operations
             nn.ReLU(),


### PR DESCRIPTION
Adapted the original bigearthnet paper baseline (zero padding was missing):

>  We selected a shallow CNN architecture, which consists of three convolutional layers with 32, 32 and 64 filters having 5 × 5, 5 × 5 and 3 × 3 filter sizes, respectively. We added one fully connected (FC) layer and one classification layer to the output of last convolutional layer.  In all convolution operations, zero padding was used. We also applied max-pooling between layers.

https://bigearth.net/static/documents/BigEarthNet_IGARSS_2019.pdf