### PR TITLE
update onehot label conversion, add test

### DIFF
--- a/bigearthnet/datamodules/bigearthnet_datamodule.py
+++ b/bigearthnet/datamodules/bigearthnet_datamodule.py
@@ -55,7 +55,7 @@ def download_data(dataset_dir, dataset_name):
 def hub_labels_to_onehot(hub_labels, n_labels):
     """Convert a multi-label from hub format to a onehot vector."""
     onehot_labels = np.zeros((n_labels,), dtype=np.int16)
-    onehot_labels[hub_labels] = 1
+    onehot_labels[[hub_labels]] = 1
     return onehot_labels
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,10 +4,27 @@ from bigearthnet.data.stats import (
     compute_class_weights,
     compute_dataloader_mean_std,
 )
+from bigearthnet.datamodules.bigearthnet_datamodule import hub_labels_to_onehot
 
 import torch
 import torchvision
 from torch.utils.data import DataLoader, Dataset
+
+
+def test_hub_labels_to_onehot():
+    n_labels = 5
+
+    hub_labels = np.array([[1], [2]])
+    onehot = hub_labels_to_onehot(hub_labels, n_labels)
+    expected_onehot = np.array([0, 1, 1, 0, 0])
+
+    assert (onehot == expected_onehot).all()
+
+    hub_labels = np.array([[0]])
+    onehot = hub_labels_to_onehot(hub_labels, n_labels)
+    expected_onehot = np.array([1, 0, 0, 0, 0])
+
+    assert (onehot == expected_onehot).all()
 
 
 def test_compute_class_counts():


### PR DESCRIPTION
The previous way of computing onehot labels was incompatible with older versions of numpy (<1.23) because of indexing. Updates the indexing to avoid this issue and adds unit test to make sure it works.